### PR TITLE
Create docker-compose.yaml for keycloak

### DIFF
--- a/keycloak + mysql/docker-compose.yaml
+++ b/keycloak + mysql/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: '3'
+
+volumes:
+  mysql_data:
+      driver: local
+
+services:
+  mysql_keycloak:
+      image: mysql:5.7
+      volumes:
+        - mysql_data:/var/lib/mysql
+      environment:
+        MYSQL_ROOT_PASSWORD: root
+        MYSQL_DATABASE: keycloak
+        MYSQL_USER: keycloak
+        MYSQL_PASSWORD: password
+        
+  keycloak:
+      image: quay.io/keycloak/keycloak:latest
+      environment:
+        DB_VENDOR: MYSQL
+        DB_ADDR: mysql_keycloak
+        DB_DATABASE: keycloak
+        DB_USER: keycloak
+        DB_PASSWORD: password
+        KEYCLOAK_ADMIN: admin
+        KEYCLOAK_ADMIN_PASSWORD: Pa55w0rd
+      ports:
+        - 8080:8080
+      depends_on:
+        - mysql_keycloak
+      command:
+        start-dev -- -b 0.0.0.0
+
+volumes:
+  mysql_data:


### PR DESCRIPTION
If role based authorization doesn't cover your needs, Keycloak provides fine-grained authorization services as well. This allows you to manage permissions for all your services from the Keycloak admin console and gives you the power to define exactly the policies you need.